### PR TITLE
allow local files in schema importer

### DIFF
--- a/lib/sekken/importer.rb
+++ b/lib/sekken/importer.rb
@@ -57,7 +57,7 @@ class Sekken
         schema.imports.each do |namespace, schema_location|
           next unless schema_location
 
-          unless absolute_url? schema_location
+          unless absolute_url? schema_location or File.readable? schema_location
             @logger.warn("Skipping XML Schema import #{schema_location.inspect}.")
             next
           end


### PR DESCRIPTION
I guess the relative URLs were skipped because there is no way to download them. Maybe if we'd configure a base url somewhere, then we could download schemas from relative URLs.

Anyways, this patch makes existing files pass the relative URL check, to fix https://github.com/savonrb/sekken/issues/14
