### PR TITLE
Move httpclient dependency into another gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pkg
 .bundle
 Gemfile.lock
 bin/
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-gemspec
+gemspec name: 'sekken'
+gemspec name: 'sekken-httpclient'
 
 # profiling
 #gem 'method_profiler', require: false

--- a/lib/sekken.rb
+++ b/lib/sekken.rb
@@ -5,7 +5,6 @@ require 'sekken/version'
 require 'sekken/errors'
 require 'sekken/wsdl'
 require 'sekken/operation'
-require 'sekken/httpclient'
 
 class Sekken
 
@@ -17,7 +16,13 @@ class Sekken
 
   # Public: Returns the HTTP adapter to use.
   def self.http_adapter
-    @http_adapter ||= HTTPClient
+    @http_adapter ||= begin
+      require 'sekken/http_adapter/httpclient'
+      HTTPClient
+    rescue LoadError
+      warn 'No http adapter set (see Sekken.http_adapter=) and default adapter (install gem sekken-httpclient) not found.'
+      raise
+    end
   end
 
   # Public: Sets the HTTP adapter to use.

--- a/lib/sekken/abstract_http_adapter.rb
+++ b/lib/sekken/abstract_http_adapter.rb
@@ -1,0 +1,29 @@
+class Sekken
+  class AbstractHttpAdapter
+    # @api 1.0
+    # @abstract
+
+    # Public: Executes an HTTP GET request to a given url.
+    #
+    # Returns the raw HTTP response body as a String.
+    #
+    # @param [String, URI] url
+    # @param [Hash<String, String>] headers
+    # @return [String] the raw body of the response
+    def get(url, headers = {})
+      fail NotImplementedError
+    end
+
+    # Public: Executes an HTTP POST request to a given url with headers and body.
+    #
+    # Returns the raw HTTP response body as a String.
+    #
+    # @param [String, URI] url
+    # @param [Hash<String, String>] headers
+    # @param [String] body
+    # @return [String] the raw body of the response
+    def post(url, headers, body)
+      fail NotImplementedError
+    end
+  end
+end

--- a/lib/sekken/http_adapter/httpclient.rb
+++ b/lib/sekken/http_adapter/httpclient.rb
@@ -1,8 +1,8 @@
+require 'sekken/abstract_http_adapter'
 require 'httpclient'
 
 class Sekken
-  class HTTPClient
-
+  class HTTPClient < AbstractHttpAdapter
     def initialize
       @client = ::HTTPClient.new
     end

--- a/sekken-httpclient.gemspec
+++ b/sekken-httpclient.gemspec
@@ -1,0 +1,26 @@
+# -*- encoding : utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$:.unshift lib unless $:.include? lib
+
+require 'sekken/version'
+
+Gem::Specification.new do |s|
+  s.name        = 'sekken-httpclient'
+  s.version     = Sekken::VERSION
+  s.authors     = ['Daniel Harrington', 'Tim Jarratt']
+  s.email       = 'tjarratt@gmail.com'
+  s.homepage    = 'http://savonrb.com'
+  s.summary     = 'HTTPClient adapter for Sekken'
+  s.description = 'Sekken is an experimental SOAP client for the Ruby community. This is the standard HTTP adapter.'
+  s.required_ruby_version = '>= 1.9.3'
+
+  s.rubyforge_project = s.name
+  s.license = 'MIT'
+
+  s.add_dependency 'httpclient', '~> 2.3'
+  s.add_dependency 'sekken', "~> #{Sekken::VERSION}"
+
+  s.files = Dir['lib/sekken/http_adapter/httpclient*']
+
+  s.require_path = 'lib'
+end

--- a/sekken.gemspec
+++ b/sekken.gemspec
@@ -33,12 +33,13 @@ Gem::Specification.new do |s|
 
   ignores  = File.readlines('.gitignore').grep(/\S+/).map(&:chomp)
   dotfiles = %w[.gitignore .travis.yml .yardopts]
+  http_adapters = Dir['lib/sekken/http_adapter/*']
 
-  all_files_without_ignores = Dir['**/*'].reject { |f|
-    File.directory?(f) || ignores.any? { |i| File.fnmatch(i, f) }
+  unexcluded_files = Dir['**/*'].reject { |f|
+    File.directory?(f) || ignores.any? { |i| File.fnmatch(i, f) } || http_adapters.any? { |i| File.fnmatch(i, f) }
   }
 
-  s.files = (all_files_without_ignores + dotfiles).sort
+  s.files = (unexcluded_files + dotfiles).sort
 
   s.require_path = 'lib'
 end

--- a/spec/sekken/httpclient_spec.rb
+++ b/spec/sekken/httpclient_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'sekken/http_adapter/httpclient'
 
 describe Sekken::HTTPClient do
 


### PR DESCRIPTION
Hi,

to be able to handle custom http-servers I did a little refactoring.

This PR extracts the dependency on httpclient into another, small gem which may be skipped.

Using Faraday as mentioned in #15 might be better, but this works for now as an interim solution until faraday is usable.

It also opens the gates for a experimental faraday adapter ;)

In hope to hear other opinions,
krissi
