### PR TITLE
Enable logging for httpclient

### DIFF
--- a/lib/sekken/httpclient.rb
+++ b/lib/sekken/httpclient.rb
@@ -4,7 +4,9 @@ class Sekken
   class HTTPClient
 
     def initialize
+      @logger = Logging.logger[self]
       @client = ::HTTPClient.new
+      @client.debug_dev = @logger
     end
 
     # Public: Returns the HTTPClient instance to configure.


### PR DESCRIPTION
When debugging issues it can be helpful to see the actual HTTP request and response body from the server. I have connected the HTTPClient `debug_dev` to the Logging gem.
