### PR TITLE
update nori version

### DIFF
--- a/sekken.gemspec
+++ b/sekken.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   # TODO: get rid of Nori.
-  s.add_dependency 'nori',     '~> 2.2.0'
+  s.add_dependency 'nori',     '~> 2.6.0'
 
   s.add_dependency 'nokogiri',   '>= 1.4.0'
   s.add_dependency 'builder',    '>= 3.0.0'


### PR DESCRIPTION
I have two projects that send requests to soap services. One project sends requests with savon 2, another - with savon 3. I decided to merge this projects. but instead of rewriting second project with savon  I want to use sekken. 

Sekken and savon 2 have nori version conflict, so I updated nori in sekken gemspec.
