### PR TITLE
update logging version to 2.0

### DIFF
--- a/sekken.gemspec
+++ b/sekken.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri',   '>= 1.4.0'
   s.add_dependency 'builder',    '>= 3.0.0'
   s.add_dependency 'httpclient', '~> 2.3'
-  s.add_dependency 'logging',    '~> 1.8'
+  s.add_dependency 'logging',    '~> 2.0'
 
   s.add_development_dependency 'rake',  '~> 10.1'
   s.add_development_dependency 'rspec', '~> 2.14'


### PR DESCRIPTION
Due to `googleauth (~> 0.5)` using `logging (~> 2.0)`.

And I run rspec, all tests are passed
